### PR TITLE
Improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Na pasta **notebooks** estão os notebooks com material e exercícios para acomp
 Para instalar o jupyter basta rodar:
 
 ```
-$ sudo apt install python3-pip
+$ sudo apt install python3-pip python3-tk
 $ pip3 install --upgrade pip3
 $ sudo pip3 install jupyter
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Maiores informações podem ser encontradas [aqui](https://uspdigital.usp.br/jup
 Na pasta **notebooks** estão os notebooks com material e exercícios para acompanhar o curso.
 
 ### Instalação(Ubuntu / Debian)
-Para  instalar o jupyter basta rodar: 
+Para instalar o jupyter basta rodar:
 
 ```
 $ sudo apt install python3-pip


### PR DESCRIPTION
 * Adiciona mais um pacote nas instruções de instalação

Ao rodar localmente, fora do jupiter notebook, não é possível plotar os gráficos sem esse pacote (ou pelo menos não consegui)

**erro:**
```
Traceback (most recent call last):
  File "/home/caio/.virtualenvs/3.5/lib/python3.5/tkinter/__init__.py", line 37, in <module>
    import _tkinter
ImportError: No module named '_tkinter'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "main.py", line 4, in <module>
    from util import get_housing_prices_data, plot_points_regression, r_squared
  File "/home/caio/usp/460/ep1/util.py", line 2, in <module>
    import matplotlib.pyplot as plt
  File "/home/caio/.virtualenvs/3.5/lib/python3.5/site-packages/matplotlib/pyplot.py", line 116, in <module>
    _backend_mod, new_figure_manager, draw_if_interactive, _show = pylab_setup()
  File "/home/caio/.virtualenvs/3.5/lib/python3.5/site-packages/matplotlib/backends/__init__.py", line 60, in pylab_setup
    [backend_name], 0)
  File "/home/caio/.virtualenvs/3.5/lib/python3.5/site-packages/matplotlib/backends/backend_tkagg.py", line 6, in <module>
    from six.moves import tkinter as Tk
  File "/home/caio/.virtualenvs/3.5/lib/python3.5/site-packages/six.py", line 92, in __get__
    result = self._resolve()
  File "/home/caio/.virtualenvs/3.5/lib/python3.5/site-packages/six.py", line 115, in _resolve
    return _import_module(self.mod)
  File "/home/caio/.virtualenvs/3.5/lib/python3.5/site-packages/six.py", line 82, in _import_module
    __import__(name)
  File "/home/caio/.virtualenvs/3.5/lib/python3.5/tkinter/__init__.py", line 39, in <module>
    raise ImportError(str(msg) + ', please install the python3-tk package')
ImportError: No module named '_tkinter', please install the python3-tk package
Error in sys.excepthook:
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/apport_python_hook.py", line 63, in apport_excepthook
    from apport.fileutils import likely_packaged, get_recent_crashes
  File "/usr/lib/python3/dist-packages/apport/__init__.py", line 5, in <module>
    from apport.report import Report
  File "/usr/lib/python3/dist-packages/apport/report.py", line 30, in <module>
    import apport.fileutils
  File "/usr/lib/python3/dist-packages/apport/fileutils.py", line 23, in <module>
    from apport.packaging_impl import impl as packaging
  File "/usr/lib/python3/dist-packages/apport/packaging_impl.py", line 24, in <module>
    import apt
  File "/usr/lib/python3/dist-packages/apt/__init__.py", line 23, in <module>
    import apt_pkg
ImportError: No module named 'apt_pkg'

Original exception was:
Traceback (most recent call last):
  File "/home/caio/.virtualenvs/3.5/lib/python3.5/tkinter/__init__.py", line 37, in <module>
    import _tkinter
ImportError: No module named '_tkinter'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "main.py", line 4, in <module>
    from util import get_housing_prices_data, plot_points_regression, r_squared
  File "/home/caio/usp/460/ep1/util.py", line 2, in <module>
    import matplotlib.pyplot as plt
  File "/home/caio/.virtualenvs/3.5/lib/python3.5/site-packages/matplotlib/pyplot.py", line 116, in <module>
    _backend_mod, new_figure_manager, draw_if_interactive, _show = pylab_setup()
  File "/home/caio/.virtualenvs/3.5/lib/python3.5/site-packages/matplotlib/backends/__init__.py", line 60, in pylab_setup
    [backend_name], 0)
  File "/home/caio/.virtualenvs/3.5/lib/python3.5/site-packages/matplotlib/backends/backend_tkagg.py", line 6, in <module>
    from six.moves import tkinter as Tk
  File "/home/caio/.virtualenvs/3.5/lib/python3.5/site-packages/six.py", line 92, in __get__
    result = self._resolve()
  File "/home/caio/.virtualenvs/3.5/lib/python3.5/site-packages/six.py", line 115, in _resolve
    return _import_module(self.mod)
  File "/home/caio/.virtualenvs/3.5/lib/python3.5/site-packages/six.py", line 82, in _import_module
    __import__(name)
  File "/home/caio/.virtualenvs/3.5/lib/python3.5/tkinter/__init__.py", line 39, in <module>
    raise ImportError(str(msg) + ', please install the python3-tk package')
ImportError: No module named '_tkinter', please install the python3-tk package
``` 