### PR TITLE
Gentle Loader, best suited for Carts

### DIFF
--- a/notebooks/pytorch_basico2.ipynb
+++ b/notebooks/pytorch_basico2.ipynb
@@ -29,9 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# notebook feito para a versão 0.4.0 do Pytorch \n",
@@ -58,9 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Essa célula pode demorar de acordo com sua conexão de internet.\n",
@@ -80,9 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "raw_X = np.load(\"self_driving_pi_car_data/train_data.npy\")\n",
@@ -93,18 +87,13 @@
     "test_X = raw_X[1000:2000]\n",
     "test_y = raw_y[1000:2000]\n",
     "train_X = raw_X[2000:]\n",
-    "train_y = raw_y[2000:]\n",
-    "\n",
-    "del raw_X\n",
-    "del raw_y"
+    "train_y = raw_y[2000:]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "command2int = {\"forward\": 0, \"left\": 1, \"right\": 2}\n",
@@ -150,9 +139,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "img9 = train_X[0:9]\n",
@@ -173,9 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "labels_legend = [\"forward\", \"left\", \"right\"]\n",
@@ -201,9 +186,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class LRConfig(object):\n",
@@ -270,9 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "lr_config = LRConfig()\n",
@@ -284,43 +265,55 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Vamos transformar as imagens em tensores e vamos usar a classe `TensorDataset` para guardar os dados."
+    "Vamos transformar as imagens em tensores e vamos usar a classe `TensorDataset` para guardar os dados.\n",
+    "\n",
+    "Ao contrário do enunciado original, que copia os tensores para ter tanto a versão com bytes como a versão com floats, aqui eu apenas fico com as coisas que já foram lidas."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from torch.utils.data import TensorDataset\n",
     "\n",
-    "train_dataset = TensorDataset(torch.Tensor(train_X),\n",
-    "                              torch.Tensor(train_y).type(torch.LongTensor))\n",
-    "valid_dataset = TensorDataset(torch.Tensor(valid_X),\n",
-    "                              torch.Tensor(valid_y).type(torch.LongTensor))\n",
-    "test_dataset = TensorDataset(torch.Tensor(test_X),\n",
-    "                              torch.Tensor(test_y).type(torch.LongTensor))"
+    "train_dataset = TensorDataset(torch.from_numpy(train_X),\n",
+    "                              torch.from_numpy(train_y))\n",
+    "valid_dataset = TensorDataset(torch.from_numpy(valid_X),\n",
+    "                              torch.from_numpy(valid_y))\n",
+    "test_dataset = TensorDataset(torch.from_numpy(test_X),\n",
+    "                             torch.from_numpy(test_y))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Para amostrar os dados vamos usar a classe `DataLoader` e vamos definir a classe `DataHolder` para exclusivamente lidar com os dados."
+    "Para amostrar os dados vamos usar a classe `DataLoader` e vamos definir a classe `DataHolder` para exclusivamente lidar com os dados.\n",
+    "\n",
+    "A classe GentleLoader é apenas um wrapper na DataLoader, que garante que os tensores só sejam convertidos para float (o que o torna 4 vezes maior) e para long (o que o torna 8 vezes maior) quando estes forem ser utilizados pelo modelo.\n",
+    "\n",
+    "Se trata, então, de uma troca, que preserva memória mas talvez deixe o treinamento mais devagar, pois pra cada vez que se acessa um batch será necessário transformar os tipos dos tensores."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from torch.utils.data import DataLoader\n",
+    "\n",
+    "class GentleLoader:\n",
+    "    def __init__(self, dataset, batch_size, shuffle):\n",
+    "        self.dataLoader = DataLoader(dataset=train_dataset,\n",
+    "                                     batch_size=batch_size,\n",
+    "                                     shuffle=True)\n",
+    "    def __iter__(self):\n",
+    "        return ((batch_X.type(torch.float), batch_y.type(torch.long))\n",
+    "                 for (batch_X, batch_y) in self.dataLoader)\n",
+    "\n",
     "\n",
     "class DataHolder():\n",
     "    \"\"\"\n",
@@ -345,15 +338,15 @@
     "                 test_dataset,\n",
     "                 test_batch=1000):\n",
     "        batch_size = config.batch_size\n",
-    "        self.train_loader = DataLoader(dataset=train_dataset,\n",
-    "                                       batch_size=batch_size,\n",
-    "                                       shuffle=True)\n",
-    "        self.valid_loader = DataLoader(dataset=valid_dataset,\n",
-    "                                       batch_size=batch_size,\n",
-    "                                       shuffle=True)\n",
-    "        self.test_loader = DataLoader(dataset=test_dataset,\n",
-    "                                      batch_size=test_batch,\n",
-    "                                      shuffle=True)"
+    "        self.train_loader = GentleLoader(dataset=train_dataset,\n",
+    "                                         batch_size=batch_size,\n",
+    "                                         shuffle=True)\n",
+    "        self.valid_loader = GentleLoader(dataset=valid_dataset,\n",
+    "                                         batch_size=batch_size,\n",
+    "                                         shuffle=True)\n",
+    "        self.test_loader = GentleLoader(dataset=test_dataset,\n",
+    "                                        batch_size=test_batch,\n",
+    "                                        shuffle=True)"
    ]
   },
   {
@@ -366,9 +359,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "self_driving_data = DataHolder(lr_config, train_dataset, valid_dataset, test_dataset) "
@@ -384,9 +375,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "batch_X, batch_y = next(iter(self_driving_data.train_loader))\n",
@@ -448,9 +437,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class LogisticRegression(nn.Module):\n",
@@ -509,9 +496,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "lr_model = LogisticRegression(lr_config)\n",
@@ -524,9 +509,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "prediction = lr_model.predict(images)\n",
@@ -544,9 +527,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "img, labels = next(iter(self_driving_data.test_loader))\n",
@@ -594,9 +575,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def train_model_img_classification(model,\n",
@@ -739,9 +718,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "img, labels = next(iter(self_driving_data.test_loader))\n",
@@ -771,9 +748,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pred9 = pred[0:9]\n",
@@ -891,9 +866,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class DFN(nn.Module):\n",
@@ -1039,9 +1012,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dfn_config = DFNConfig(architecture=[200, 100, 3])\n",
@@ -1063,9 +1034,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "img, labels = next(iter(self_driving_data.test_loader))\n",
@@ -1089,9 +1058,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pred9 = pred[0:9]\n",
@@ -1174,7 +1141,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Do not copy all the images into float matrices in order to preserve memory. Only does the copy when computation is about to be done.

Does this through an iterator that wraps PyTorch DataLoader.

May slow down training, but makes the notebook way more suitable for computers with 4gb RAM or less.