### PR TITLE
Sugestão: utilizar ambientes virtuais

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Um pedaço da parte teórica do curso foi baseado no curso [**Learning from Data
 Na pasta **notebooks** estão os exercícios práticos dados no curso, na pasta **slides** estão os materiais didáticos de algumas aulas.
 
 ### Instalação (Ubuntu / Debian)
+Para quem desejar, recomendamos a utilização de ambientes virtuais.
+[Instale os pacotes necessários](http://railslide.io/virtualenvwrapper-python3.html) e crie um novo ambiente, ex:
+
+```
+$ mkvirtualenv mac0460
+$ workon mac0460
+```
+
 Para instalar o [Jupyter Notebook](http://jupyter.org/) basta rodar:
 
 ```


### PR DESCRIPTION
Ao usar ambientes virtuais, instalamos as bibliotecas no path do ambiente ao invés do "path" global, evitando:
 - Que a instalação de versões diferentes da mesma biblioteca "quebre" projetos diferentes (na mesma máquina).
 - Que vire uma zona em geral.

Além disso, se o usuário não for mais trabalhar com algum projeto, basta remover o ambiente virtual e todas as bibliotecas serão automaticamente removidas (e não sobram dúzias de bibliotecas inúteis e desatualizadas instaladas na máquina).